### PR TITLE
feat: allow clients to specify their import method, optionally ignore it

### DIFF
--- a/src/connectStoreController.ts
+++ b/src/connectStoreController.ts
@@ -18,6 +18,7 @@ export default function (
   initOpts: {
     remotePrefix: string,
     concurrency?: number,
+    packageImportMethod: 'auto' | 'hardlink' | 'copy' | 'reflink',
   },
 ): Promise<StoreServerController> {
   const remotePrefix = initOpts.remotePrefix
@@ -26,13 +27,15 @@ export default function (
   return new Promise((resolve, reject) => {
     resolve({
       close: async () => { return },
+      // this importPackage does not take a packageImportMethod, because on a client connecting to the pnpm server, we
+      // can use directly the packageImportMethod specified in the initOpts
       importPackage: async (from: string, to: string, opts: {
         filesResponse: PackageFilesResponse,
         force: boolean,
       }) => {
         await limitedFetch(`${remotePrefix}/importPackage`, {
           from,
-          opts,
+          opts: Object.assign(opts, { packageImportMethod: initOpts.packageImportMethod }),
           to,
         })
       },

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -104,7 +104,7 @@ export default function (
           break
         case '/importPackage':
           const importPackageBody = (await bodyPromise) as any // tslint:disable-line:no-any
-          if (opts.ignorePackageImportMethod && (opts.storePackageImportMethod !== importPackageBody.opts.packageImportMethod)) {
+          if (opts.ignorePackageImportMethod && importPackageBody.opts.packageImportMethod && (opts.storePackageImportMethod !== importPackageBody.opts.packageImportMethod)) {
             res.statusCode = 403
             res.end()
             break

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -28,6 +28,8 @@ export default function (
     port?: number,
     hostname?: string,
     ignoreStopRequests?: boolean,
+    ignorePackageImportMethod?: boolean,
+    storePackageImportMethod: 'auto' | 'hardlink' | 'copy' | 'reflink',
   },
 ) {
   const manifestPromises = {}
@@ -102,6 +104,11 @@ export default function (
           break
         case '/importPackage':
           const importPackageBody = (await bodyPromise) as any // tslint:disable-line:no-any
+          if (opts.ignorePackageImportMethod && (opts.storePackageImportMethod !== importPackageBody.opts.packageImportMethod)) {
+            res.statusCode = 403
+            res.end()
+            break
+          }
           await store.importPackage(importPackageBody.from, importPackageBody.to, importPackageBody.opts)
           res.end(JSON.stringify('OK'))
           break

--- a/test/index.ts
+++ b/test/index.ts
@@ -45,8 +45,8 @@ test('server', async t => {
   const remotePrefix = `http://${hostname}:${port}`
   const storeCtrlForServer = await createStoreController()
   const server = createServer(storeCtrlForServer, {
-    port,
     hostname,
+    port,
   })
   const storeCtrl = await connectStoreController({remotePrefix, concurrency: 100})
   const response = await storeCtrl.requestPackage(


### PR DESCRIPTION
I am unsure if I should return a 403 or show a warning. I would lend toward only showing a warning